### PR TITLE
Feat/saswwn

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,14 +6,13 @@ We take the security of the csi-lib-sas project seriously. If you find any secur
 
 :warning: **Please do not publicly report any security vulnerabilities via GitHub issues.**
 
-If you have concerns or questions, please email us at [opensource@seagate.com](mailto:opensource@seagate.com). 
+If you have concerns or questions, please email us at [opensource@seagate.com](mailto:opensource@seagate.com).
 
 To report an actual vulnerability, please use the "[Seagate Responsible Vulnerability Disclosure Policy](https://www.seagate.com/legal-privacy/responsible-vulnerability-disclosure-policy/)"
- 
 
 ### Reporting Format
 
-To make your reporting meaningful and help us understand the nature and scope of the issue, please include as much information as possible. 
+To make your reporting meaningful and help us understand the nature and scope of the issue, please include as much information as possible.
 
 ### Preferred Languages
 

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -5,4 +5,3 @@
 #
 
 opensource@seagate.com
-

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -3,12 +3,6 @@
 # They are the contact point for the Product Security Team to reach out
 # to for triaging and handling of incoming issues.
 #
-# The below names agree to abide by the
-# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
-# and will be removed and replaced if they violate that agreement.
-#
-# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
-# INSTRUCTIONS AT https://kubernetes.io/security/
 
-jskazinski
+opensource@seagate.com
 

--- a/example/main.go
+++ b/example/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	// Use command line arguments for test settings
 	c := sas.Connector{
-		TargetWWN: *wwn,
+		VolumeWWN: *wwn,
 	}
 
 	dp, err := sas.Attach(ctx, &c, &sas.OSioHandler{})

--- a/sas/sas_test.go
+++ b/sas/sas_test.go
@@ -89,7 +89,7 @@ func TestSearchDisk(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	fakeConnector := Connector{
 		VolumeName: "fakeVol",
-		TargetWWN:  "3600508b400105e210000900000490000",
+		VolumeWWN:  "3600508b400105e210000900000490000",
 	}
 
 	error := discoverDevices(logger, &fakeConnector, &fakeIOHandler{})


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Changes to SAS Connector parameter names and adding comments.

```release-note
- For SAS Connector, TargetWWN was renamed to VolumeWWN (Passed In: 128 bit world wide name given to storage volume.)
- For SAS Connector, TargetDevice was renamed to OSPathName (Discovered: The OS path to the storage volume WWN, for example /dev/sdb or /dev/dm-5)
- For SAS Connector, SCSIDevices was renamed to OSDevicePaths (Discovered: The OS path(s) to the storage volume WWN, for example ["/dev/sdb"] or ["/dev/sdb", "/dev/sdc"])
```


-----
[View rendered SECURITY.md](https://github.com/Seagate/csi-lib-sas/blob/feat/saswwn/SECURITY.md)